### PR TITLE
Move CI to ubuntu 20.04 from deprecated 18.04 runners

### DIFF
--- a/.github/workflows/check_release_label.yml
+++ b/.github/workflows/check_release_label.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check_labels:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: smartlyio/check-versioning-action@v5
       with:

--- a/.github/workflows/pull_request.generated.yml
+++ b/.github/workflows/pull_request.generated.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set Node.js 12.x
@@ -40,7 +40,7 @@ jobs:
         npm run package
 
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/release.generated.yml
+++ b/.github/workflows/release.generated.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set Node.js 12.x
@@ -40,7 +40,7 @@ jobs:
         npm run package
 
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: "Build and release action"
     needs: [build]
     steps:


### PR DESCRIPTION
GitHub is deliberately causing CI failures on ubuntu-18.04; we need to switch everything