### PR TITLE
Finish node 16 -> 20 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-    - name: Set Node.js 16.x
+    - name: Set Node.js 20.x
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
     - name: "Install"
       run: |
         npm install


### PR DESCRIPTION
So there was this warning:  
![image](https://github.com/smartlyio/find-changes-action/assets/61745723/0167e76f-dd9c-48e8-98c7-46e8252c07fa)
https://github.com/smartlyio/panamax/actions/runs/9498519488

Which goes away with this PR, tested at https://github.com/smartlyio/panamax/pull/352/commits/feacb94a0ac53a01ac478b37023ce7cecf05f4ed. See below how it has no annotations:  
![image](https://github.com/smartlyio/find-changes-action/assets/61745723/075feb9a-f43f-4dfc-9a03-3bdefeaf300a)  
https://github.com/smartlyio/panamax/actions/runs/9499403243