### PR TITLE
Fix release workflow 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         npm run package
 
   test:
+    if: github.event.pull_request.merged == false
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,12 @@
 name: Build and release the action
 
-# smartlyio/find-changes-action@v1 (under Release flow) only works on pull_request events is the reason for not using "on: push: branches: master"
 on:
-  pull_request:
+  push:
     branches: [master]
-    types: [closed]
 
 jobs:
   build:
     name: Build
-    # Only run when PR is closed AND merged, not when PR is just closed.
-    if: github.event.pull_request.merged
     uses: ./.github/workflows/build.yml
     secrets: inherit
 


### PR DESCRIPTION
#347 tried to solve the issue where the workflow wouldn't run due to workflow being called from master: push. This uncovers the issue where branch protection rules are hit:
![image](https://github.com/smartlyio/find-changes-action/assets/61745723/ce92a204-e3de-45a6-a379-5b1bd8d22e16)

So this PR replaces the workaround from the previous one by not running tests on master push as they would've been ran already as part of the PR.

Long term, the intention is to update this workflow to run even on master push, allowing this workaround to be reverted as well and a lot of the other workflows depending on this one being simplified.

---

[Selectively bypassing branch protection rules for github actions is not possible](https://github.com/orgs/community/discussions/25305#discussioncomment-3247401)* as anyone could push anything just by creating a branch and coding the workflow to push to another branch.

\* [there's a workaround](https://github.com/orgs/community/discussions/25305#discussioncomment-8256560), but it's a rather involved process -- my intention is to make an attempt at making this workflow work on master push as well, to simplify a lot of the workflows depending on this action.
