### PR TITLE
Reapply "Fix release workflow (#347)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
 name: Build and release the action
 
+# smartlyio/find-changes-action@v1 (under Release flow) only works on pull_request events is the reason for not using "on: push: branches: master"
 on:
-  push:
+  pull_request:
     branches: [master]
+    types: [closed]
 
 jobs:
   build:
     name: Build
+    # Only run when PR is closed AND merged, not when PR is just closed.
+    if: github.event.pull_request.merged
     uses: ./.github/workflows/build.yml
     secrets: inherit
 


### PR DESCRIPTION
This reverts commit d00fbe6315389200284c0224da2f723ed35ede3e.

The if at https://github.com/smartlyio/find-changes-action/blob/d00fbe6315389200284c0224da2f723ed35ede3e/.github/workflows/build.yml#L33 is seemingly not working under master push, so bringing the workaround from #347 back